### PR TITLE
Flushing behavior updated to allow flushing on submit CSV

### DIFF
--- a/Assets/VERA/Editor/VERALoggerEditor.cs
+++ b/Assets/VERA/Editor/VERALoggerEditor.cs
@@ -101,7 +101,7 @@ public class VERALoggerEditor : Editor
 
       if (GUILayout.Button("Submit CSV"))
       {
-        csvWriter.SubmitCSV(csvWriter.filePath);
+        csvWriter.SubmitCSV(csvWriter.filePath, true);
       }
 
       if (GUILayout.Button("Clear Files"))

--- a/Assets/VERA/VERALogger.cs
+++ b/Assets/VERA/VERALogger.cs
@@ -142,14 +142,18 @@ public class VERALogger : MonoBehaviour
   {
     SubmitCSV(filePath);
   }
-  public void SubmitCSV(string file)
+  public void SubmitCSV(string file, bool flushOnSubmit = false)
   {
     Debug.Log(file);
-    StartCoroutine(SubmitCSVWrapper(file));
+    StartCoroutine(SubmitCSVWrapper(file, flushOnSubmit));
   }
 
-  private IEnumerator SubmitCSVWrapper(string file)
+  private IEnumerator SubmitCSVWrapper(string file, bool flushOnSubmit = false)
   {
+    if (flushOnSubmit)
+    {
+      Flush();
+    }
     onBeginFileUpload?.Invoke();
     yield return StartCoroutine(SubmitCSVCoroutine(file));
     onFileUploadExited?.Invoke();
@@ -401,12 +405,13 @@ public class VERALogger : MonoBehaviour
     if (cache.Count >= cacheSizeLimit || timeSinceLastFlush >= flushInterval)
     {
       Flush();
-      timeSinceLastFlush = 0f;
     }
   }
 
   private void Flush()
   {
+    timeSinceLastFlush = 0f;
+
     if (cache.Count == 0)
     {
       return;


### PR DESCRIPTION
Pressing submit in the inspector will now flush the cache before submission. Other calls to submit can specify cache flushing, optionally and default not triggered.