### PR TITLE
Change Progress Route Address Update

### DIFF
--- a/Assets/VERA/VERALogger.cs
+++ b/Assets/VERA/VERALogger.cs
@@ -146,10 +146,9 @@ public class VERALogger : MonoBehaviour
 
     // Create the Web request for the experiment progress
     string host = development ? host_dev : host_live;
-    //string progressURL = host + "/api/progress/" + study_UUID + "/" + participant_UUID + "/" + progressParam.ToString();
 
     // server expects enums in lower case
-    string progressURL = host + "/api/progress/" + study_UUID + "/" + participant_UUID + "/" + state.ToString().ToLower();
+    string progressURL = host + "/api/" + study_UUID + "/" + participant_UUID + "/progress/" + state.ToString().ToLower();
 
     byte[] myData = null;
 
@@ -195,7 +194,7 @@ public class VERALogger : MonoBehaviour
     {
       Flush();
     }
-    
+
     onBeginFileUpload?.Invoke();
     yield return StartCoroutine(SubmitCSVCoroutine(file));
     onFileUploadExited?.Invoke();
@@ -453,7 +452,7 @@ public class VERALogger : MonoBehaviour
   private void Flush()
   {
     timeSinceLastFlush = 0f;
-    
+
     if (cache.Count == 0)
     {
       return;


### PR DESCRIPTION
Changed the Route Address for the ChangeProgress Function in the VERA Logger to reflect the change in the route address on the web server side.

Originally it was:  **http://localhost:4000/api/progress/:studyId/:playerId/:progress**

Now it is changed to:  **http://localhost:4000/api/:studyId/:playerId/progress/:progress**

If you want to confirm the new route is correct, go to the WEB application of the Vera project., and check the route in this file in this folder directory: **server/src/routes/api/study.ts**

The route will be on line 107